### PR TITLE
Update badge link to point to the new maturity documentation

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -1,4 +1,4 @@
-[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://community.finos.org/docs/governance/Software-Projects/stages/incubating)
+[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle#incubating)
 
 # {project name}
 


### PR DESCRIPTION
This PR updates the badge link from `/stages/` to `/project-lifecycle#` to reflect the new FINOS documentation structure.

- Old format: `https://community.finos.org/docs/governance/software-projects/stages/{stage}/`
- New format: `https://community.finos.org/docs/governance/Software-Projects/project-lifecycle#{stage}`
- Note: `active` stage has been changed to `graduated`