### PR TITLE
Add MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+# Maintainers
+
+This file lists the maintainers of this repository.
+
+For information about maintainer responsibilities and resources, please see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
+
+| GitHub Username | Name | Email |
+|----------------|------|-------|
+| @[2026-01-16 16:58:46] [INFO]   Fetching finos-admins team members to exclude... |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding finos-admins team member: TheJuanAndOnly99 |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding finos-admins team member: maoo |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding finos-admins team member: mindthegab |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding finos-admins team member: opoupeney |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding finos-admins team member: robmoffat |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding service account/bot: finos-admin |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Excluding service account/bot: thelinuxfoundation |  |  |
+| @[2026-01-16 16:58:47] [INFO]     Found 5 finos-admins team members to exclude |  |  |
+| @[2026-01-16 16:58:47] [INFO]   Fetching collaborators with maintainer or admin role... |  |  |
+| @[2026-01-16 16:58:47] [INFO]   Fetching teams with maintainer role... |  |  |
+| @[2026-01-16 16:58:48] [INFO]     Skipping FINOS team: finos-admins |  |  |
+


### PR DESCRIPTION
This PR adds a MAINTAINERS.md file listing all repository maintainers.

The maintainers are determined from:
- Users with `maintain` role on the repository
- Teams with `maintain` role on the repository (excluding FINOS organization teams)

Each maintainer entry includes their GitHub username, name, and email from their GitHub profile.

## Review Request

Please review this PR and:
1. **Verify the maintainer list is complete and accurate**
2. **Check that all maintainer details (name, email) are correct**
3. **Update any incorrect information** (names, emails, etc.)**
4. **If there are any missing maintainers** who should be included but were not automatically detected or if any maintainers are missing from the list, please email help@finos.org

If you notice any issues or missing information, please either:
- Comment on this PR with the corrections, or
- Make the changes directly to this branch

Thank you for your review!