### PR TITLE
Add canonical SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@ This project supports responsible disclosure of security vulnerabilities and adh
 ## Reporting a Vulnerability
 
 - **GitHub private vulnerability reporting (preferred):** Use the ["Report a vulnerability"](../../security/advisories/new) button under this repository's **Security** tab. This opens a private advisory and communication channel with the maintainers.
-- **Email:** If you're unable to use GitHub's private reporting, email the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) and cc [security@finos.org](mailto:security@finos.org) with a description of the issue.
+- **Email:** If you're unable to use GitHub's private reporting, email [security@finos.org](mailto:security@finos.org) with a description of the issue. If maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md), you may also email them and cc [security@finos.org](mailto:security@finos.org).
 
 ## Vulnerability Process
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+This project supports responsible disclosure of security vulnerabilities and adheres to the [FINOS Security Vulnerabilities Responsible Disclosure Policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure). If you believe you have found a security vulnerability in this project, we encourage and appreciate your report. Please report it privately using one of the methods below — **do not** open a public GitHub Issue or otherwise disclose it publicly.
+
+## Reporting a Vulnerability
+
+- **GitHub private vulnerability reporting (preferred):** Use the ["Report a vulnerability"](../../security/advisories/new) button under this repository's **Security** tab. This opens a private advisory and communication channel with the maintainers.
+- **Email:** If you're unable to use GitHub's private reporting, email the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) and cc [security@finos.org](mailto:security@finos.org) with a description of the issue.
+
+## Vulnerability Process
+
+1. **Report the vulnerability privately** using one of the methods above.
+2. The project team will acknowledge receipt, triage the report, and — if confirmed — work with you to investigate and develop a fix.
+3. Once a fix is available, it will be released and the vulnerability will be publicly disclosed in accordance with the [FINOS Security Vulnerabilities Responsible Disclosure Policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure).
+
+Thank you for helping keep FINOS projects and their users secure.


### PR DESCRIPTION
Adds a canonical `SECURITY.md` to the blueprint so projects created from it get a standard security policy out of the box, instead of each project hand-rolling its own (as flagged in finos/technical-oversight-committee#297).

This follows the same reporting flow as `finos/git-proxy`'s policy (the most current of the existing FINOS examples): GitHub private vulnerability reporting as the preferred channel, with email to `security@finos.org` as a fallback, and links to the [FINOS Security Vulnerabilities Responsible Disclosure Policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure).

Scoped to `software-project-blueprint` only — extending this as an org-wide default via `finos/.github` was raised as a separate, bigger discussion in the issue and isn't part of this PR.